### PR TITLE
Remove Mantine and switch to Recharts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,6 @@
             "version": "0.1.0",
             "dependencies": {
                 "@heroicons/react": "^2.0.17",
-                "@mantine/charts": "^7.17.8",
-                "@mantine/core": "^7.17.8",
-                "@mantine/dropzone": "^7.17.8",
-                "@mantine/hooks": "^7.17.8",
                 "@types/lodash.clonedeep": "^4.5.7",
                 "@types/node": "18.15.11",
                 "@types/react": "18.0.35",
@@ -28,6 +24,7 @@
                 "prettier-plugin-tailwindcss": "^0.2.7",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
+                "react-dropzone": "^14.2.3",
                 "react-toastify": "^10.0.5",
                 "recharts": "^2.15.4",
                 "tailwindcss": "3.3.1",
@@ -105,59 +102,6 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
-        },
-        "node_modules/@floating-ui/core": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
-            "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/utils": "^0.2.9"
-            }
-        },
-        "node_modules/@floating-ui/dom": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
-            "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/core": "^1.7.0",
-                "@floating-ui/utils": "^0.2.9"
-            }
-        },
-        "node_modules/@floating-ui/react": {
-            "version": "0.26.28",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-            "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/react-dom": "^2.1.2",
-                "@floating-ui/utils": "^0.2.8",
-                "tabbable": "^6.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
-        "node_modules/@floating-ui/react-dom": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-            "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/dom": "^1.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
-        "node_modules/@floating-ui/utils": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-            "license": "MIT"
         },
         "node_modules/@heroicons/react": {
             "version": "2.0.17",
@@ -254,74 +198,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "license": "MIT"
-        },
-        "node_modules/@mantine/charts": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@mantine/charts/-/charts-7.17.8.tgz",
-            "integrity": "sha512-lzDa2JM0uD2X32vnUPtERJc4V5nYkrbpOpnC/G3p0Kkwcxh9v59p5uMDxHXoHcv/OsMPALKYWBkY9aGWvD/E4g==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@mantine/core": "7.17.8",
-                "@mantine/hooks": "7.17.8",
-                "react": "^18.x || ^19.x",
-                "react-dom": "^18.x || ^19.x",
-                "recharts": "^2.13.3"
-            }
-        },
-        "node_modules/@mantine/core": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz",
-            "integrity": "sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==",
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/react": "^0.26.28",
-                "clsx": "^2.1.1",
-                "react-number-format": "^5.4.3",
-                "react-remove-scroll": "^2.6.2",
-                "react-textarea-autosize": "8.5.9",
-                "type-fest": "^4.27.0"
-            },
-            "peerDependencies": {
-                "@mantine/hooks": "7.17.8",
-                "react": "^18.x || ^19.x",
-                "react-dom": "^18.x || ^19.x"
-            }
-        },
-        "node_modules/@mantine/core/node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@mantine/dropzone": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-7.17.8.tgz",
-            "integrity": "sha512-c9WEArpP23E9tbRWqoznEY3bGPVntMuBKr3F2LQijgdpdALIzt6DYmwXu7gUajGX9Qg9NrCHenhvWLTYqKnRlA==",
-            "license": "MIT",
-            "dependencies": {
-                "react-dropzone-esm": "15.2.0"
-            },
-            "peerDependencies": {
-                "@mantine/core": "7.17.8",
-                "@mantine/hooks": "7.17.8",
-                "react": "^18.x || ^19.x",
-                "react-dom": "^18.x || ^19.x"
-            }
-        },
-        "node_modules/@mantine/hooks": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
-            "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^18.x || ^19.x"
-            }
         },
         "node_modules/@next/env": {
             "version": "13.3.0",
@@ -1071,6 +947,15 @@
             "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
             "license": "ISC"
         },
+        "node_modules/attr-accept": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+            "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/autoprefixer": {
             "version": "10.4.14",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
@@ -1598,12 +1483,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/detect-node-es": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-            "license": "MIT"
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -2292,6 +2171,18 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/file-selector": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+            "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.7.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2425,15 +2316,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-nonce": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/get-symbol-description": {
@@ -4037,12 +3919,14 @@
                 "react": "^18.2.0"
             }
         },
-        "node_modules/react-dropzone-esm": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/react-dropzone-esm/-/react-dropzone-esm-15.2.0.tgz",
-            "integrity": "sha512-pPwR8xWVL+tFLnbAb8KVH5f6Vtl397tck8dINkZ1cPMxHWH+l9dFmIgRWgbh7V7jbjIcuKXCsVrXbhQz68+dVA==",
+        "node_modules/react-dropzone": {
+            "version": "14.3.8",
+            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+            "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
             "license": "MIT",
             "dependencies": {
+                "attr-accept": "^2.2.4",
+                "file-selector": "^2.1.0",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -4058,63 +3942,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "license": "MIT"
         },
-        "node_modules/react-number-format": {
-            "version": "5.4.4",
-            "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
-            "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/react-remove-scroll": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
-            "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
-            "license": "MIT",
-            "dependencies": {
-                "react-remove-scroll-bar": "^2.3.7",
-                "react-style-singleton": "^2.2.3",
-                "tslib": "^2.1.0",
-                "use-callback-ref": "^1.3.3",
-                "use-sidecar": "^1.1.3"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-remove-scroll-bar": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-            "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-            "license": "MIT",
-            "dependencies": {
-                "react-style-singleton": "^2.2.2",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/react-smooth": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -4128,45 +3955,6 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/react-style-singleton": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-            "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-            "license": "MIT",
-            "dependencies": {
-                "get-nonce": "^1.0.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-textarea-autosize": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-            "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.20.13",
-                "use-composed-ref": "^1.3.0",
-                "use-latest": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react-toastify": {
@@ -4664,12 +4452,6 @@
                 "url": "https://opencollective.com/unts"
             }
         },
-        "node_modules/tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-            "license": "MIT"
-        },
         "node_modules/tailwindcss": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
@@ -4812,9 +4594,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
         "node_modules/tsutils": {
@@ -4937,94 +4719,6 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/use-callback-ref": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-composed-ref": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-            "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-isomorphic-layout-effect": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
-            "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-latest": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-            "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-            "license": "MIT",
-            "dependencies": {
-                "use-isomorphic-layout-effect": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-sidecar": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "detect-node-es": "^1.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
     },
     "dependencies": {
         "@heroicons/react": "^2.0.17",
-        "@mantine/charts": "^7.17.8",
-        "@mantine/core": "^7.17.8",
-        "@mantine/dropzone": "^7.17.8",
-        "@mantine/hooks": "^7.17.8",
+        "react-dropzone": "^14.2.3",
         "@types/lodash.clonedeep": "^4.5.7",
         "@types/node": "18.15.11",
         "@types/react": "18.0.35",

--- a/src/components/materials/PolymerVideoViewer.tsx
+++ b/src/components/materials/PolymerVideoViewer.tsx
@@ -5,11 +5,9 @@ import {
     spheresMap,
     subtract,
 } from "@/components/materials/crystalViewerHelpers";
-import { Checkbox, Slider } from "@mantine/core";
 import React, { useRef, useEffect, useState, useCallback } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import "@mantine/core/styles.css";
 
 export interface Frame {
     atomicNumbers: number[];
@@ -245,25 +243,25 @@ const PolymerVideoViewerCanvas = ({
     return (
         <>
             <div ref={mountRef} style={{ width: "100%", height: "100%" }} />
-            <div className="mt-2 flex flex-row">
-                <Checkbox
-                    checked={isUseFrameSliderCheckedRef.current}
-                    onChange={(event) =>
-                        (isUseFrameSliderCheckedRef.current = event.currentTarget.checked)
-                    }
-                    label="Use Frame Slider"
-                />
-                <Slider
+            <div className="mt-2 flex flex-row items-center gap-2">
+                <label className="flex items-center gap-1 text-sm">
+                    <input
+                        type="checkbox"
+                        checked={isUseFrameSliderCheckedRef.current}
+                        onChange={(event) =>
+                            (isUseFrameSliderCheckedRef.current = event.currentTarget.checked)
+                        }
+                    />
+                    Use Frame Slider
+                </label>
+                <input
+                    type="range"
                     disabled={!isUseFrameSliderCheckedRef.current}
-                    className="w-[100%]"
+                    className="w-full"
                     value={sliderValueRef.current}
-                    onChange={(v) => (sliderValueRef.current = v)}
-                    color="blue"
-                    marks={[
-                        { value: 20, label: "20%" },
-                        { value: 50, label: "50%" },
-                        { value: 80, label: "80%" },
-                    ]}
+                    onChange={(e) => (sliderValueRef.current = Number(e.target.value))}
+                    min={0}
+                    max={100}
                 />
             </div>
         </>

--- a/src/pages/materials/human-iap.tsx
+++ b/src/pages/materials/human-iap.tsx
@@ -3,10 +3,18 @@ import { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { CrystalViewer } from '@/components/materials/CrystalViewer';
 import { CustomSlider } from '@/components/materials/CustomSlider';
-import { MantineProvider } from '@mantine/core';
-import { ScatterChart, BarChart } from '@mantine/charts';
-import '@mantine/core/styles.css';
-import '@mantine/charts/styles.css';
+import {
+  ScatterChart as RechartsScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  BarChart as RechartsBarChart,
+  Bar,
+  ResponsiveContainer,
+  Label,
+} from 'recharts';
 
 
 interface Material {
@@ -211,7 +219,6 @@ export default function MP20Guesser({ materials }: Props) {
   }
 
   return (
-    <MantineProvider>
       <div className="min-h-screen py-4 px-4 sm:px-6 lg:px-8">
         <div className="max-w-6xl mx-auto">
           {/* Header */}
@@ -383,24 +390,22 @@ export default function MP20Guesser({ materials }: Props) {
               <div className="mb-8">
                 <h4 className="text-md font-medium text-gray-700 my-4 text-center">Error Over Time</h4>
                 <div className="h-64 -ml-4 sm:ml-0">
-                  <ScatterChart
-                    h={250}
-                    data={[
-                      {
-                        color: 'blue.6',
-                        name: 'Your Guesses',
-                        data: guessHistory.map((guess, index) => ({
-                          x: index + 1,
-                          y: guess.error
-                        }))
-                      }
-                    ]}
-                    dataKey={{ x: 'x', y: 'y' }}
-                    xAxisLabel="Attempt #"
-                    yAxisLabel="Error (eV/atom)"
-                    withTooltip
-                    yAxisProps={{ width: 37 }}
-                  />
+                  <ResponsiveContainer width="100%" height={250}>
+                    <RechartsScatterChart>
+                      <CartesianGrid />
+                      <XAxis type="number" dataKey="x">
+                        <Label value="Attempt #" position="insideBottom" offset={-5} />
+                      </XAxis>
+                      <YAxis type="number" dataKey="y" width={37}>
+                        <Label value="Error (eV/atom)" angle={-90} position="insideLeft" />
+                      </YAxis>
+                      <RechartsTooltip />
+                      <Scatter
+                        data={guessHistory.map((guess, index) => ({ x: index + 1, y: guess.error }))}
+                        fill="#2563EB"
+                      />
+                    </RechartsScatterChart>
+                  </ResponsiveContainer>
                 </div>
               </div>
 
@@ -408,9 +413,9 @@ export default function MP20Guesser({ materials }: Props) {
               <div className="mb-4">
                 <h4 className="text-md font-medium text-gray-700 mb-4 text-center">Error Histogram</h4>
                 <div className="h-64 -ml-4 sm:ml-0">
-                  <BarChart
-                    h={250}
-                    data={(() => {
+                  <ResponsiveContainer width="100%" height={250}>
+                    <RechartsBarChart
+                      data={(() => {
                       // Create histogram bins
                       const binSize = 0.1;
                       const maxError = Math.max(...guessHistory.map(g => g.error));
@@ -431,13 +436,18 @@ export default function MP20Guesser({ materials }: Props) {
 
                       return bins.filter(bin => bin.count > 0);
                     })()}
-                    dataKey="range"
-                    series={[{ name: 'count', color: 'blue.6' }]}
-                    xAxisLabel="Error Range (eV/atom)"
-                    yAxisLabel="# Guesses"
-                    withTooltip
-                    yAxisProps={{ width: 37 }}
-                  />
+                    >
+                      <CartesianGrid />
+                      <XAxis dataKey="range">
+                        <Label value="Error Range (eV/atom)" position="insideBottom" offset={-5} />
+                      </XAxis>
+                      <YAxis width={37}>
+                        <Label value="# Guesses" angle={-90} position="insideLeft" />
+                      </YAxis>
+                      <RechartsTooltip />
+                      <Bar dataKey="count" fill="#2563EB" />
+                    </RechartsBarChart>
+                  </ResponsiveContainer>
                 </div>
               </div>
             </div>
@@ -447,7 +457,6 @@ export default function MP20Guesser({ materials }: Props) {
 
         </div>
       </div>
-    </MantineProvider>
   );
 }
 

--- a/src/pages/materials/polymers.tsx
+++ b/src/pages/materials/polymers.tsx
@@ -3,7 +3,6 @@ import { Frame, PolymerVideoViewer } from "@/components/materials/PolymerVideoVi
 import React from "react";
 import pull from "public/materials/pull.json";
 import relaxation from "public/materials/relaxation.json";
-import { MantineProvider } from "@mantine/core";
 import Image from "next/image";
 
 export default function Polymers() {
@@ -39,8 +38,7 @@ export default function Polymers() {
     }, []);
 
     return (
-        <MantineProvider>
-            <div className="px-3 text-md">
+        <div className="px-3 text-md">
                 <p className="fade-in-on-scroll mt-20 text-center text-2xl">
                     Building Polymers with Neural Network Potentials
                 </p>
@@ -181,6 +179,5 @@ export default function Polymers() {
                 <p className="fade-in-on-scroll mt-10">- Curtis</p>
                 <div className="h-96"></div>
             </div>
-        </MantineProvider>
     );
 }

--- a/src/pages/materials/trajectory.tsx
+++ b/src/pages/materials/trajectory.tsx
@@ -1,9 +1,8 @@
 import { PolymerVideoViewer } from "@/components/materials/PolymerVideoViewer";
-import { Dropzone, FileWithPath } from "@mantine/dropzone";
+import { useDropzone } from "react-dropzone";
 import React from "react";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { MantineProvider } from "@mantine/core";
 
 export interface Frame {
     atomicNumbers: number[];
@@ -15,7 +14,7 @@ export const TrajectoryPage = () => {
     const [frames, setFrames] = React.useState<Frame[]>([]);
     // const [forces, setForces] = React.useState<number[][]>([]);
 
-    const onDrop = React.useCallback((files: FileWithPath[]) => {
+    const onDrop = React.useCallback((files: File[]) => {
         if (files.length > 1) {
             toast.error("Please only upload one file at a time");
             return;
@@ -31,26 +30,30 @@ export const TrajectoryPage = () => {
         reader.readAsText(uploadedFile);
     }, []);
 
+    const { getRootProps, getInputProps } = useDropzone({
+        accept: { 'application/json': ['.traj'] },
+        onDrop,
+    });
+
     return (
-        <MantineProvider>
-            <div>
-                <div className="flex flex-col items-center">
+        <div>
+            <div className="flex flex-col items-center">
                     <h1 className="mt-10 text-2xl font-bold">Trajectory Viewer</h1>
                     <p>
                         this page doesn't work. we need a function to interpret the Python-generated
                         ase file (a binary) in Typescript
                     </p>
-                    <Dropzone
-                        className="mt-10 h-40 w-[80%] cursor-pointer rounded-xl border-[1px] border-dashed border-slate-400 px-8 pb-10 pt-8"
-                        accept={{ "application/json": [".traj"] }}
-                        onDrop={onDrop}
+                    <div
+                        {...getRootProps({
+                            className: 'mt-10 h-40 w-[80%] cursor-pointer rounded-xl border-[1px] border-dashed border-slate-400 px-8 pb-10 pt-8',
+                        })}
                     >
-                        {/* Content inside the Dropzone */}
+                        <input {...getInputProps()} />
                         <div className="flex h-full flex-col items-center justify-center">
                             <h1 className="mb-4 text-2xl font-bold">Drop your relaxation</h1>
                             <p className="text-gray-500">.traj files accepted</p>
                         </div>
-                    </Dropzone>
+                    </div>
                     <p>frames: {frames.length}</p>
                     <div className="h-[800px] w-[1000px]">
                         {/*  TODO: fix this viewer. rn the frames are missing coords. obv when we parse the traj file, we'll get the coords */}
@@ -59,7 +62,6 @@ export const TrajectoryPage = () => {
                     <ToastContainer />
                 </div>
             </div>
-        </MantineProvider>
-    );
+        );
 };
 export default TrajectoryPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.21.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -40,42 +40,6 @@
   version "8.38.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz"
   integrity sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==
-
-"@floating-ui/core@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz"
-  integrity sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==
-  dependencies:
-    "@floating-ui/utils" "^0.2.9"
-
-"@floating-ui/dom@^1.0.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz"
-  integrity sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==
-  dependencies:
-    "@floating-ui/core" "^1.7.0"
-    "@floating-ui/utils" "^0.2.9"
-
-"@floating-ui/react-dom@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz"
-  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
-  dependencies:
-    "@floating-ui/dom" "^1.0.0"
-
-"@floating-ui/react@^0.26.28":
-  version "0.26.28"
-  resolved "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz"
-  integrity sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==
-  dependencies:
-    "@floating-ui/react-dom" "^2.1.2"
-    "@floating-ui/utils" "^0.2.8"
-    tabbable "^6.0.0"
-
-"@floating-ui/utils@^0.2.8", "@floating-ui/utils@^0.2.9":
-  version "0.2.9"
-  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz"
-  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@heroicons/react@^2.0.17":
   version "2.0.17"
@@ -138,35 +102,6 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mantine/charts@^7.17.8":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/charts/-/charts-7.17.8.tgz"
-  integrity sha512-lzDa2JM0uD2X32vnUPtERJc4V5nYkrbpOpnC/G3p0Kkwcxh9v59p5uMDxHXoHcv/OsMPALKYWBkY9aGWvD/E4g==
-
-"@mantine/core@^7.17.8", "@mantine/core@7.17.8":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz"
-  integrity sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==
-  dependencies:
-    "@floating-ui/react" "^0.26.28"
-    clsx "^2.1.1"
-    react-number-format "^5.4.3"
-    react-remove-scroll "^2.6.2"
-    react-textarea-autosize "8.5.9"
-    type-fest "^4.27.0"
-
-"@mantine/dropzone@^7.17.8":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-7.17.8.tgz"
-  integrity sha512-c9WEArpP23E9tbRWqoznEY3bGPVntMuBKr3F2LQijgdpdALIzt6DYmwXu7gUajGX9Qg9NrCHenhvWLTYqKnRlA==
-  dependencies:
-    react-dropzone-esm "15.2.0"
-
-"@mantine/hooks@^7.17.8", "@mantine/hooks@7.17.8":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz"
-  integrity sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==
-
 "@next/env@13.3.0":
   version "13.3.0"
   resolved "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz"
@@ -183,6 +118,46 @@
   version "13.3.0"
   resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz"
   integrity sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==
+
+"@next/swc-darwin-x64@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz"
+  integrity sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==
+
+"@next/swc-linux-arm64-gnu@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz"
+  integrity sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==
+
+"@next/swc-linux-arm64-musl@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz"
+  integrity sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==
+
+"@next/swc-linux-x64-gnu@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz"
+  integrity sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==
+
+"@next/swc-linux-x64-musl@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz"
+  integrity sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==
+
+"@next/swc-win32-arm64-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz"
+  integrity sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==
+
+"@next/swc-win32-ia32-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz"
+  integrity sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==
+
+"@next/swc-win32-x64-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz"
+  integrity sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -526,6 +501,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+attr-accept@^2.2.4:
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz"
+  integrity sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==
+
 autoprefixer@10.4.14:
   version "10.4.14"
   resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz"
@@ -653,7 +633,7 @@ client-only@0.0.1:
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
-clsx@^2.0.0, clsx@^2.1.0, clsx@^2.1.1:
+clsx@^2.0.0, clsx@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -834,11 +814,6 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-detect-node-es@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz"
-  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1248,6 +1223,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-selector@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz"
+  integrity sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==
+  dependencies:
+    tslib "^2.7.0"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
@@ -1326,11 +1308,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
-
-get-nonce@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz"
-  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -2206,7 +2183,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-"react-dom@^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^18.2.0, "react-dom@^18.x || ^19.x", react-dom@>=16.6.0, react-dom@>=16.8.0, react-dom@>=18, react-dom@18.2.0:
+"react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^18.2.0, react-dom@>=16.6.0, react-dom@>=18, react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -2214,11 +2191,13 @@ quick-lru@^5.1.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-dropzone-esm@15.2.0:
-  version "15.2.0"
-  resolved "https://registry.npmjs.org/react-dropzone-esm/-/react-dropzone-esm-15.2.0.tgz"
-  integrity sha512-pPwR8xWVL+tFLnbAb8KVH5f6Vtl397tck8dINkZ1cPMxHWH+l9dFmIgRWgbh7V7jbjIcuKXCsVrXbhQz68+dVA==
+react-dropzone@^14.2.3:
+  version "14.3.8"
+  resolved "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz"
+  integrity sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==
   dependencies:
+    attr-accept "^2.2.4"
+    file-selector "^2.1.0"
     prop-types "^15.8.1"
 
 react-is@^16.13.1:
@@ -2231,30 +2210,6 @@ react-is@^18.3.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-number-format@^5.4.3:
-  version "5.4.4"
-  resolved "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz"
-  integrity sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==
-
-react-remove-scroll-bar@^2.3.7:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz"
-  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
-  dependencies:
-    react-style-singleton "^2.2.2"
-    tslib "^2.0.0"
-
-react-remove-scroll@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz"
-  integrity sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==
-  dependencies:
-    react-remove-scroll-bar "^2.3.7"
-    react-style-singleton "^2.2.3"
-    tslib "^2.1.0"
-    use-callback-ref "^1.3.3"
-    use-sidecar "^1.1.3"
-
 react-smooth@^4.0.4:
   version "4.0.4"
   resolved "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz"
@@ -2263,23 +2218,6 @@ react-smooth@^4.0.4:
     fast-equals "^5.0.1"
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
-
-react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz"
-  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
-  dependencies:
-    get-nonce "^1.0.0"
-    tslib "^2.0.0"
-
-react-textarea-autosize@8.5.9:
-  version "8.5.9"
-  resolved "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz"
-  integrity sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==
-  dependencies:
-    "@babel/runtime" "^7.20.13"
-    use-composed-ref "^1.3.0"
-    use-latest "^1.2.1"
 
 react-toastify@^10.0.5:
   version "10.0.6"
@@ -2298,7 +2236,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^18.2.0, "react@^18.x || ^19.x", "react@>= 16", "react@>= 16.8 || 18.0.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16.6.0, react@>=16.8.0, react@>=18, react@18.2.0:
+"react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^18.2.0, "react@>= 16", "react@>= 16.8 || 18.0.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16.6.0, react@>=18, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -2326,7 +2264,7 @@ recharts-scale@^0.4.4:
   dependencies:
     decimal.js-light "^2.4.1"
 
-recharts@^2.13.3, recharts@^2.15.4:
+recharts@^2.15.4:
   version "2.15.4"
   resolved "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz"
   integrity sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==
@@ -2570,11 +2508,6 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
-tabbable@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz"
-  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
-
 tailwindcss@3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz"
@@ -2674,10 +2607,10 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+tslib@^2.4.0, tslib@^2.5.0, tslib@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -2697,11 +2630,6 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^4.27.0:
-  version "4.41.0"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
-  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 typed-array-length@^1.0.4:
   version "1.0.4"
@@ -2741,38 +2669,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-use-callback-ref@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz"
-  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
-  dependencies:
-    tslib "^2.0.0"
-
-use-composed-ref@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz"
-  integrity sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==
-
-use-isomorphic-layout-effect@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz"
-  integrity sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==
-
-use-latest@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz"
-  integrity sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==
-  dependencies:
-    use-isomorphic-layout-effect "^1.1.1"
-
-use-sidecar@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz"
-  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
-  dependencies:
-    detect-node-es "^1.1.0"
-    tslib "^2.0.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- drop Mantine packages
- build polymer viewer controls with native inputs
- swap Mantine charts for Recharts on the human IAP page
- update polymers and trajectory pages to no longer rely on Mantine

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68867b3e46b0832e993487f724bd6f57