### PR TITLE
Fix human-iap card padding

### DIFF
--- a/src/pages/materials/human-iap.tsx
+++ b/src/pages/materials/human-iap.tsx
@@ -341,8 +341,8 @@ export default function MP20Guesser({ materials }: Props) {
                         <span className="hidden sm:inline">Next Material →</span>
                       </button>
                     </div>
-                    {currentGuessResult && (
-                      <div className="mt-4">
+                    <div className="mt-4 min-h-16">
+                      {currentGuessResult && (
                         <div className="text-sm text-gray-600 space-y-1 text-center">
                           {isNewBestGuess && (
                             <div className="mt-2 px-3 py-2 bg-green-100 border border-green-300 rounded-md">
@@ -359,8 +359,8 @@ export default function MP20Guesser({ materials }: Props) {
                             </div>
                           )}
                         </div>
-                      </div>
-                    )}
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- keep padding stable in the human-IAP guess card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68867e9c3bb8832ea111bf88a060a292