### PR TITLE
Fix PolymerVideoViewer initialization

### DIFF
--- a/src/components/materials/PolymerVideoViewer.tsx
+++ b/src/components/materials/PolymerVideoViewer.tsx
@@ -161,7 +161,7 @@ const PolymerVideoViewerCanvas = ({
             if (stepRef.current === 10) {
                 stepRef.current = 0;
                 currentFrameRef.current = (currentFrame + 1) % processedFrames.length;
-                drawFrame(processedFrames[currentFrame]);
+                drawFrame(processedFrames[currentFrameRef.current]);
                 // console.log(currentFrame);
             }
         }
@@ -177,13 +177,7 @@ const PolymerVideoViewerCanvas = ({
             }
             clearSpheres();
         };
-    }, [
-        processedFrames,
-        currentSpheresRef.current,
-        sceneRef.current,
-        cameraRef.current,
-        rendererRef.current,
-    ]);
+    }, [processedFrames, clearSpheres]);
 
     // I don't think we can cache processed frames and pre-add the atoms them to the scene
     // because if we move the camera and flip between scenes, it'll change?
@@ -227,18 +221,18 @@ const PolymerVideoViewerCanvas = ({
         controls.minDistance = 5; // Set the minimum zoom-in distance
         controls.maxDistance = furthestDistFromOrigin; // Set the maximum zoom-out distance
 
-        animate();
-
         controlsRef.current = controls;
         sceneRef.current = scene;
         cameraRef.current = camera;
         rendererRef.current = renderer;
 
+        animate();
+
         // Clean up on unmount
         return () => {
             mount.removeChild(renderer.domElement);
         };
-    }, [processedFrames]);
+    }, [processedFrames, animate, furthestDistFromOrigin]);
 
     return (
         <>

--- a/src/components/materials/PolymerVideoViewer.tsx
+++ b/src/components/materials/PolymerVideoViewer.tsx
@@ -171,12 +171,6 @@ const PolymerVideoViewerCanvas = ({
         if (cameraRef.current && sceneRef.current && rendererRef.current) {
             rendererRef.current.render(sceneRef.current, cameraRef.current);
         }
-        return () => {
-            if (animationFrameIdRef.current) {
-                cancelAnimationFrame(animationFrameIdRef.current);
-            }
-            clearSpheres();
-        };
     }, [processedFrames, clearSpheres]);
 
     // I don't think we can cache processed frames and pre-add the atoms them to the scene
@@ -230,7 +224,12 @@ const PolymerVideoViewerCanvas = ({
 
         // Clean up on unmount
         return () => {
+            if (animationFrameIdRef.current) {
+                cancelAnimationFrame(animationFrameIdRef.current);
+            }
+            clearSpheres();
             mount.removeChild(renderer.domElement);
+            renderer.dispose();
         };
     }, [processedFrames, animate, furthestDistFromOrigin]);
 


### PR DESCRIPTION
## Summary
- fix off-by-one when drawing next frame
- avoid stale refs by assigning them before animation starts
- simplify animation callback dependencies
- update viewer setup effect dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68867e334e54832e8da9ff82810f9805